### PR TITLE
Wave: wait for draw improve speed

### DIFF
--- a/src/components/wave/wave.js
+++ b/src/components/wave/wave.js
@@ -30,7 +30,9 @@ const Wave = () => {
 
 
   useEffect(() => {
-    redraw();
+    setTimeout(() => {
+      redraw();
+    }, 2000);
     window.addEventListener('resize', redraw);
     return () => {
       window.removeEventListener('resize', redraw);


### PR DESCRIPTION
#20 

This seems to improve the analysis as the load of the wave is not included in the first paint. It does not have a big negative visual effect.

