### PR TITLE
Remove of blog file content from gatsby-config

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -31,13 +31,6 @@ module.exports = {
     {
       resolve: `gatsby-source-filesystem`,
       options: {
-        path: `${__dirname}/content/blog`,
-        name: `blog`,
-      },
-    },
-    {
-      resolve: `gatsby-source-filesystem`,
-      options: {
         path: `${__dirname}/content/assets`,
         name: `assets`,
       },


### PR DESCRIPTION
This now fixes the build. 

Seems like when you are testing you need to do:
`gatsby clean` then the build otherwise it doesn't not match the build in the cloud.