### PR TITLE
Blog/automatic classification for peace invite

### DIFF
--- a/content/assets/blog/automatic-classifiers-for-peace-invite/index.md
+++ b/content/assets/blog/automatic-classifiers-for-peace-invite/index.md
@@ -1,0 +1,20 @@
+---
+title: Automatic Classifiers for Peace Invite
+date: "2023-04-14T04:23:05Z"
+description: "Are you interested in joining the Automatic Classifiers for Peace group?"
+author: benjamin
+---
+Hello!,
+
+datavaluepeople (https://datavaluepeople.com/) and Build Up (https://howtobuildup.org/) are working on a new project, the Automatic Classifiers for Peace group, and we would love to know if you might be interested in joining.
+
+The Automatic Classifiers for Peace group helps to further the development of open-source text classification systems for peacebuilding and mediation. Build Up has been developing classification systems for peacebuilding in collaboration with datavaluepeople: with a set of open-source social media analysis tools collectively called Phoenix: https://gitlab.com/howtobuildup/phoenix. Phoenix is also a process that guides peacebuilders and mediators in conducting relevant social media analysis. The Phoenix process and tools have already been used by 100s of local peacebuilders and helped them find valuable insight into ways they can help the communities they care about.
+
+A key component of Phoenix is the capacity to build customizable automatic classification models that support the analysis needs of peacebuilders and mediators. We know other organisations are also interested in this particular capability. With Automatic Classifiers for Peace, we hope to widen and deepen the number of organisations involved in open-source text classification systems for peacebuilding. The project will build the structures necessary so that we can collaborate to share collective knowledge and build upon each other's work rather than siloed. Our aim is to create tools and code repositories that are accessible, easy to use and can attract other technologists to work on them too, as well as to release software tools, guidance and documentation directed towards peacebuilders with different levels of tech literacy.
+
+Ultimately, we hope to make tools usable by any local peacebuilder that can do automatic text classification of social media discourse in the communities and languages peacebuilders think are important. These tools will be connected to the community of peacebuilders that are already using Phoenix - a community which Build Up is fronting and helps peacebuilders that are looking at how they can use social media analysis.
+
+The Automatic Classifiers for Peace group will be meeting online a number of times throughout the year, once in June, and once in the autumn. These online meetings will lead up to a real-life 2-day workshop in Nairobi on Nov 29 & 30, just before Build Up's yearly international peacebuilding conference Build Peace 2023 in the same location. These meetings will be facilitated by datavaluepeople and Build Up and will hopefully create the relationships and structure for the group to be effective, worthwhile and fun.
+
+We are looking for people and organisations that have an understanding and have worked with building text classifications. They have experience in building software and are passionate or work in peacebuilding. If you are interested please contact benjamin@datavaluepeople.com with your CV and a short motivation message/letter.
+

--- a/docs/blog.md
+++ b/docs/blog.md
@@ -20,7 +20,7 @@ hackernews_link: https://blog.otterstack.com/posts/202212-doom-calculator/
 
 Description of the meta properties:
 - `title`: title of the page and the post
-- `date`: to order the post on the blog page. The most recent posts will be displayed first.
+- `date`: to order the post on the blog page. The most recent posts will be displayed first. CLI command `date -u +"%Y-%m-%dT%H:%M:%SZ"`
 - `description`: short description on the blog page that is used on the blog page (listing of the posts) and the social media links. Keep this short ~300 characters.
 - `author`: link to the author in `content/data/people.yaml`
 - `linkedin_link`: (Optional) link to the LinkedIn post that will be added to the bottom of the post as "Discuss further on LinkedIn"


### PR DESCRIPTION
The invite for the automated classifications for peace group.

I am going to use this to send out invites on linked in with connection requests. I thought it might be a good way to also get a blog post out. 

I could also use a [google doc](https://docs.google.com/document/d/1VntglkwSmPHUX9B0Ac6kEj54Vk0bRaDrY287zhbNbxI/edit?usp=sharing) but is it not as fun. 

What do you think?