### PR TITLE
Add markdown linting for blog posts

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,9 @@
+config:
+  # MD013/line-length - Line length
+  MD013:
+    # Number of characters - set to match what we use in python
+    line_length: 99
+    # Number of characters for headings
+    heading_line_length: 99
+    # Number of characters for code blocks
+    code_block_line_length: 99

--- a/README.md
+++ b/README.md
@@ -39,12 +39,6 @@ gatsby develop
 
 If you install something with `npm` you will need to do it in a session that has `nvm use` initialised.
 
-Once you have node and gatsby installed:
-```
-npm install
-gatsby develop
-```
-
 ## Deployment
 Currently the repo is set up to deploy to the firebase. That was done follow this [tutorial](https://www.gatsbyjs.org/docs/deploying-to-firebase/).
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,6 +6,9 @@ steps:
     entrypoint: npm
     args: ["ci"]
   - name: node:16.15.0
+    entrypoint: "./node_modules/.bin/markdownlint-cli2"
+    args: ["**/*.md", "#node_modules"]
+  - name: node:16.15.0
     entrypoint: npm
     args: ["install", "gatsby-cli@4.15.0"]
   - name: node:16.15.0

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
     args: ["ci"]
   - name: node:16.15.0
     entrypoint: "./node_modules/.bin/markdownlint-cli2-config"
-    args: [".markdownlint-cli2.yaml", "content/assets/blog/**/*.md", "#node_modules"]
+    args: [".markdownlint-cli2.yaml", "content/assets/blog/**/*.md"]
   - name: node:16.15.0
     entrypoint: npm
     args: ["install", "gatsby-cli@4.15.0"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,8 +6,8 @@ steps:
     entrypoint: npm
     args: ["ci"]
   - name: node:16.15.0
-    entrypoint: "./node_modules/.bin/markdownlint-cli2"
-    args: ["content/assets/blog/**/*.md", "#node_modules"]
+    entrypoint: "./node_modules/.bin/markdownlint-cli2-config"
+    args: [".markdownlint-cli2.yaml", "content/assets/blog/**/*.md", "#node_modules"]
   - name: node:16.15.0
     entrypoint: npm
     args: ["install", "gatsby-cli@4.15.0"]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,7 +7,7 @@ steps:
     args: ["ci"]
   - name: node:16.15.0
     entrypoint: "./node_modules/.bin/markdownlint-cli2"
-    args: ["**/*.md", "#node_modules"]
+    args: ["content/assets/blog/**/*.md", "#node_modules"]
   - name: node:16.15.0
     entrypoint: npm
     args: ["install", "gatsby-cli@4.15.0"]

--- a/content/assets/blog/test/hello-world/index.md
+++ b/content/assets/blog/test/hello-world/index.md
@@ -31,6 +31,7 @@ const saltyDuckEgg = "chinese preserved food product"
 ```
 
 Longer code:
+
 ```js
 const saltyDuckEgg = "chinese preserved food product" fjkdjfslkjfkdjflskjdfkljsldkjflksdjflkjdslkfjlkdsjfkldjklfsj
 ```
@@ -45,20 +46,6 @@ const saltyDuckEgg = "chinese preserved food product" fjkdjfslkjfkdjflskjdfkljsl
 
 This is a paragraph.
 
-    This is a paragraph.
-
-# Header 1
-
-## Header 2
-
-    Header 1
-    ========
-
-    Header 2
-    --------
-
-# Header 1
-
 ## Header 2
 
 ### Header 3
@@ -69,74 +56,23 @@ This is a paragraph.
 
 ###### Header 6
 
-    # Header 1
-    ## Header 2
-    ### Header 3
-    #### Header 4
-    ##### Header 5
-    ###### Header 6
-
-# Header 1
-
-## Header 2
-
-### Header 3
-
-#### Header 4
-
-##### Header 5
-
-###### Header 6
-
-    # Header 1 #
-    ## Header 2 ##
-    ### Header 3 ###
-    #### Header 4 ####
-    ##### Header 5 #####
-    ###### Header 6 ######
-
-> Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
-
-    > Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus. Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
-
-> ## This is a header.
+> Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aliquam hendrerit mi posuere lectus.
+> Vestibulum enim wisi, viverra nec, fringilla in, laoreet vitae, risus.
+>
+> ## This is a header
 >
 > 1. This is the first list item.
 > 2. This is the second list item.
 >
 > Here's some example code:
 >
->     Markdown.generate();
-
-    > ## This is a header.
-    > 1. This is the first list item.
-    > 2. This is the second list item.
-    >
-    > Here's some example code:
-    >
-    >     Markdown.generate();
-
-- Red
-- Green
-- Blue
-
-* Red
-* Green
-* Blue
+> ```Markdown.generate();```
 
 - Red
 - Green
 - Blue
 
 ```markdown
-- Red
-- Green
-- Blue
-
-* Red
-* Green
-* Blue
-
 - Red
 - Green
 - Blue
@@ -170,33 +106,17 @@ This is a paragraph.
 
 Paragraph:
 
-    Code
+```markdown
+Code
+```
 
 <!-- -->
 
-    Paragraph:
-
-        Code
-
 ---
 
+```markdown
 ---
-
----
-
----
-
----
-
-    * * *
-
-    ***
-
-    *****
-
-    - - -
-
-    ---------------------------------------
+```
 
 This is [an example](http://example.com "Example") link.
 
@@ -206,6 +126,7 @@ This is [an example][id] reference-style link.
 
 [id]: http://example.com "Optional Title"
 
+```markdown
     This is [an example](http://example.com "Example") link.
 
     [This link](http://example.com) has no title attr.
@@ -213,27 +134,26 @@ This is [an example][id] reference-style link.
     This is [an example] [id] reference-style link.
 
     [id]: http://example.com "Optional Title"
+```
 
-_single asterisks_
+Text with *single asterisks*
 
-_single underscores_
+Text with **double asterisks**
 
-**double asterisks**
+```markdown
+Text with *single asterisks*
 
-**double underscores**
-
-    *single asterisks*
-
-    _single underscores_
-
-    **double asterisks**
-
-    __double underscores__
+Text with **double asterisks**
+```
 
 This paragraph has some `code` in it.
 
-    This paragraph has some `code` in it.
+```markdown
+This paragraph has some `code` in it.
+```
 
 ![Alt Text](https://placehold.it/200x50 "Image Title")
 
+```markdown
     ![Alt Text](https://placehold.it/200x50 "Image Title")
+```

--- a/content/assets/blog/test/new-beginnings/index.md
+++ b/content/assets/blog/test/new-beginnings/index.md
@@ -52,11 +52,11 @@ Commas, wild Question Marks and devious Semikoli, but the Little Blind Text
 didn’t listen. She packed her seven versalia, put her initial into the belt and
 made herself on the way.
 
-1.  So baboon this
-2.  Mounted militant weasel gregariously admonishingly straightly hey
-3.  Dear foresaw hungry and much some overhung
-4.  Rash opossum less because less some amid besides yikes jeepers frenetic
-    impassive fruitlessly shut
+1. So baboon this
+2. Mounted militant weasel gregariously admonishingly straightly hey
+3. Dear foresaw hungry and much some overhung
+4. Rash opossum less because less some amid besides yikes jeepers frenetic impassive fruitlessly
+   shut
 
 When she reached the first hills of the Italic Mountains, she had a last view
 back on the skyline of her hometown Bookmarksgrove, the headline of Alphabet

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "eslint": "^8.16.0",
         "eslint-config-google": "^0.14.0",
         "eslint-plugin-react": "^7.21.5",
+        "markdownlint-cli2": "^0.6.0",
         "sass": "^1.30.0"
       }
     },
@@ -13498,6 +13499,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "node_modules/linkify-it": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+      "dev": true,
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "node_modules/lmdb": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.3.tgz",
@@ -13783,6 +13793,34 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
+      "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "~3.0.1",
+        "linkify-it": "^4.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/markdown-table": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
@@ -13793,6 +13831,101 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/markdownlint": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.27.0.tgz",
+      "integrity": "sha512-HtfVr/hzJJmE0C198F99JLaeada+646B5SaG2pVoEakLFI6iRGsvMqrnnrflq8hm1zQgwskEgqSnhDW11JBp0w==",
+      "dev": true,
+      "dependencies": {
+        "markdown-it": "13.0.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/markdownlint-cli2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.6.0.tgz",
+      "integrity": "sha512-Bv20r6WGdcHMWi8QvAFZ3CBunf4i4aYmVdTfpAvXODI/1k3f09DZZ0i0LcX9ZMhlVxjoOzbVDz1NWyKc5hwTqg==",
+      "dev": true,
+      "dependencies": {
+        "globby": "13.1.3",
+        "markdownlint": "0.27.0",
+        "markdownlint-cli2-formatter-default": "0.0.3",
+        "micromatch": "4.0.5",
+        "strip-json-comments": "5.0.0",
+        "yaml": "2.2.1"
+      },
+      "bin": {
+        "markdownlint-cli2": "markdownlint-cli2.js",
+        "markdownlint-cli2-config": "markdownlint-cli2-config.js",
+        "markdownlint-cli2-fix": "markdownlint-cli2-fix.js"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/markdownlint-cli2-formatter-default": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.3.tgz",
+      "integrity": "sha512-QEAJitT5eqX1SNboOD+SO/LNBpu4P4je8JlR02ug2cLQAqmIhh8IJnSK7AcaHBHhNADqdGydnPpQOpsNcEEqCw==",
+      "dev": true,
+      "peerDependencies": {
+        "markdownlint-cli2": ">=0.0.4"
+      }
+    },
+    "node_modules/markdownlint-cli2/node_modules/globby": {
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
+      "integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
+      "dev": true,
+      "dependencies": {
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.11",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdownlint-cli2/node_modules/slash": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+      "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdownlint-cli2/node_modules/strip-json-comments": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.0.tgz",
+      "integrity": "sha512-V1LGY4UUo0jgwC+ELQ2BNWfPa17TIuwBLg+j1AA/9RPzKINl1lhxVEu2r+ZTTO8aetIsUzE5Qj6LMSBkoGYKKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/markdownlint-cli2/node_modules/yaml": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
+      "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/md5-file": {
@@ -19649,6 +19782,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true
     },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
@@ -30737,6 +30876,15 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "linkify-it": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-4.0.1.tgz",
+      "integrity": "sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==",
+      "dev": true,
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
+    },
     "lmdb": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/lmdb/-/lmdb-2.5.3.tgz",
@@ -30980,6 +31128,27 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
     },
+    "markdown-it": {
+      "version": "13.0.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-13.0.1.tgz",
+      "integrity": "sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1",
+        "entities": "~3.0.1",
+        "linkify-it": "^4.0.1",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+          "dev": true
+        }
+      }
+    },
     "markdown-table": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-2.0.0.tgz",
@@ -30987,6 +31156,69 @@
       "requires": {
         "repeat-string": "^1.0.0"
       }
+    },
+    "markdownlint": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.27.0.tgz",
+      "integrity": "sha512-HtfVr/hzJJmE0C198F99JLaeada+646B5SaG2pVoEakLFI6iRGsvMqrnnrflq8hm1zQgwskEgqSnhDW11JBp0w==",
+      "dev": true,
+      "requires": {
+        "markdown-it": "13.0.1"
+      }
+    },
+    "markdownlint-cli2": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.6.0.tgz",
+      "integrity": "sha512-Bv20r6WGdcHMWi8QvAFZ3CBunf4i4aYmVdTfpAvXODI/1k3f09DZZ0i0LcX9ZMhlVxjoOzbVDz1NWyKc5hwTqg==",
+      "dev": true,
+      "requires": {
+        "globby": "13.1.3",
+        "markdownlint": "0.27.0",
+        "markdownlint-cli2-formatter-default": "0.0.3",
+        "micromatch": "4.0.5",
+        "strip-json-comments": "5.0.0",
+        "yaml": "2.2.1"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "13.1.3",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.3.tgz",
+          "integrity": "sha512-8krCNHXvlCgHDpegPzleMq07yMYTO2sXKASmZmquEYWEmCx6J5UTRbp5RwMJkTJGtcQ44YpiUYUiN0b9mzy8Bw==",
+          "dev": true,
+          "requires": {
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.2.11",
+            "ignore": "^5.2.0",
+            "merge2": "^1.4.1",
+            "slash": "^4.0.0"
+          }
+        },
+        "slash": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+          "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.0.tgz",
+          "integrity": "sha512-V1LGY4UUo0jgwC+ELQ2BNWfPa17TIuwBLg+j1AA/9RPzKINl1lhxVEu2r+ZTTO8aetIsUzE5Qj6LMSBkoGYKKw==",
+          "dev": true
+        },
+        "yaml": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.1.tgz",
+          "integrity": "sha512-e0WHiYql7+9wr4cWMx3TVQrNwejKaEe7/rHNmQmqRjazfOP5W8PB6Jpebb5o6fIapbz9o9+2ipcaTM2ZwDI6lw==",
+          "dev": true
+        }
+      }
+    },
+    "markdownlint-cli2-formatter-default": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.3.tgz",
+      "integrity": "sha512-QEAJitT5eqX1SNboOD+SO/LNBpu4P4je8JlR02ug2cLQAqmIhh8IJnSK7AcaHBHhNADqdGydnPpQOpsNcEEqCw==",
+      "dev": true,
+      "requires": {}
     },
     "md5-file": {
       "version": "5.0.0",
@@ -35235,6 +35467,12 @@
       "version": "0.7.32",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.32.tgz",
       "integrity": "sha512-f9BESNVhzlhEFf2CHMSj40NWOjYPl1YKYbrvIr/hFTDEmLq7SRbWvm7FcdcpCYT95zrOhC7gZSxjdnnTpBcwVw=="
+    },
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint": "^8.16.0",
     "eslint-config-google": "^0.14.0",
     "eslint-plugin-react": "^7.21.5",
+    "markdownlint-cli2": "^0.6.0",
     "sass": "^1.30.0"
   },
   "homepage": "https://github.com/gatsbyjs/gatsby-starter-blog#readme",


### PR DESCRIPTION
See build: https://console.cloud.google.com/cloud-build/builds;region=global/ef4907f2-4f6b-4750-ab89-09de90ab0bcf?project=dvp-landing-266011 which successfully fails due to markdown linting errors. 

@benjamincerigo decisions: 
- Should we add this? 
- For all md files? 
- Just for blog posts? 
- Just for blog posts that are not in the `test` dir? (This is the most easy one as we don't have to update the old md files to pass the linting, and gives us what we want, which is linting on all future blog posts. So I reckon we should do this one.)